### PR TITLE
fix problem in deepphe-viz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /deepphe-uima/deepphe-uima.iml
 /deepphe-workbench/deepphe-workbench.iml
 /resources/
+/deepphe-uima/testdb
+./deepphe-viz/project/.sbtserver

--- a/deepphe-viz/app/db/Neo4JRESTCaller.java
+++ b/deepphe-viz/app/db/Neo4JRESTCaller.java
@@ -117,7 +117,7 @@ public class Neo4JRESTCaller {
         List<LinkedHashMap<String, Object>> out = new ArrayList<LinkedHashMap<String, Object>>();
         
         for(Object o:rows){
-        	LinkedHashMap<String, Object> rowmap = (LinkedHashMap<String, Object>)rows[0];
+	    LinkedHashMap<String, Object> rowmap = (LinkedHashMap<String, Object>) o;
         	
         	
         	LinkedHashMap<String, Object> datamap = (LinkedHashMap<String, Object>) rowmap.get("data");

--- a/deepphe-viz/project/.sbtserver
+++ b/deepphe-viz/project/.sbtserver
@@ -1,3 +1,3 @@
-#Server Startup at 2016-01-12T15:02+0000
-#Tue Jan 12 10:02:27 EST 2016
-server.uri=http\://0.0.0.0\:58958
+#Server Startup at 2016-02-22T03:17+0000
+#Sun Feb 21 22:17:43 EST 2016
+server.uri=http\://0.0.0.0\:57101


### PR DESCRIPTION
Neo4JRestCaller had a problem in objectifyRelationshipJSON. 

        for(Object o:rows){
	    LinkedHashMap<String, Object> rowmap = (LinkedHashMap<String, Object>) rows[0];

was not iterating over the list - rather, it was looking at the first element in the list each time.

change "rows[0] to "o"
